### PR TITLE
New features

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -288,10 +288,10 @@ module.exports = {
   EMPTY_ALL: {
     code: 63,
     encrypted: true,
-    args: false,
-    device: ['SMART Hopper', 'SMART Payout', 'NV11'],
+    args: true,
+    device: ['SMART Hopper', 'SMART Payout', 'NV11', 'NV4000'],
     description:
-      'This command will direct all stored monies to the cash box without reporting any value and reset all the stored counters to zero. See Smart Empty command to record the value emptied.',
+      'This command will direct all stored monies to the cash box without reporting any value and reset all the stored counters to zero. See Smart Empty command to record the value emptied. For NV4000 devices it accepts as an argument the desired module to empty',
   },
   SET_COIN_MECH_INHIBITS: {
     code: 64,

--- a/src/status_desc.js
+++ b/src/status_desc.js
@@ -7,6 +7,10 @@ module.exports = {
     name: 'REPLENISH_STORED',
     description: 'Event received when the device has completed the Replenish Stored Notes (0x80) command'
   },
+  115: {
+    name: 'REPLENISHMENT_CASSETTE_TRAY_FULL',
+    description: 'NV4000 Replenishment cassette tray full'
+  },
   116: {
     name: 'NOTE_TO_RC_TRAY',
     description: 'When a rejected note from replenishment cassette is moved to the reject tray of the cassette'
@@ -103,6 +107,10 @@ module.exports = {
   206: {
     name: 'NOTE_HELD_IN_BEZEL',
     description: 'Reported when a dispensing note is held in the bezel of the payout device.',
+  },
+  207: {
+    name: 'DEVICE_FULL',
+    description: 'The device has detected that it is full of coins/banknotes and no more can be added.',
   },
   209: {
     name: 'BAR_CODE_TICKET_ACKNOWLEDGE',

--- a/src/utils.js
+++ b/src/utils.js
@@ -387,7 +387,6 @@ function parseData(data, currentCommand, protocolVersion, deviceUnitType) {
       //TODO parse all modules
       switch (data[0]){
         case 0x03:
-          console.log(data)
           const moduleFlags = data[11].toString(2).padStart(8,'0')
           result.info.module = "Replenishment Cassette"
           result.info.note_value = Buffer.from(data.slice(2,6)).readInt32LE()
@@ -554,7 +553,6 @@ function parseData(data, currentCommand, protocolVersion, deviceUnitType) {
         }
       } else if (currentCommand === 'CASHBOX_PAYOUT_OPERATION_DATA') {
         result.info = { res: {} }
-        console.log(data)
         for (let i = 0; i < data[0]; i++) {
           result.info.res[i] = {
             quantity: Buffer.from(data.slice(i * 9 + 2, i * 9 + 4)).readInt16LE(),


### PR DESCRIPTION
- The EMPTY_ALL command when using a NV4000 device accepts a parameter where we can tell which module we want to empty

- The events   REPLENISHMENT_CASSETTE_TRAY_FULL and DEVICE_FULL were added

- Replenismhent cassette flag parsing on command MODULE_INFO fixed 