### PR TITLE
Bug fixed when creating diffie hellman prime numbers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,13 +109,21 @@ module.exports = class SSP extends EventEmitter {
     return this.id | this.sequence
   }
 
+  validateBufferSize(primeBuffer){
+    if (primeBuffer.length < 2) {
+      primeBuffer = Buffer.concat([Buffer.alloc(2 - primeBuffer.length, 0), primeBuffer]);
+    }
+    return primeBuffer
+  }
+
   initEncryption() {
     return Promise.all([
-      BigInt(dh.createDiffieHellman(16).getPrime().readUInt16BE()),
-      BigInt(dh.createDiffieHellman(16).getPrime().readUInt16BE()),
-      BigInt(dh.createDiffieHellman(16).getPrime().readUInt16BE()),
+      BigInt(this.validateBufferSize(dh.createDiffieHellman(16).getPrime()).readUInt16BE()),
+      BigInt(this.validateBufferSize(dh.createDiffieHellman(16).getPrime()).readUInt16BE()),
+      BigInt(this.validateBufferSize(dh.createDiffieHellman(16).getPrime()).readUInt16BE()),
     ])
       .then(res => {
+        res.sort((a, b) => (a > b ? -1 : 1));
         this.keys.generatorKey = res[0]
         this.keys.modulusKey = res[1]
         this.keys.hostRandom = res[2]


### PR DESCRIPTION
Problem: 

The encryption sequence was causing the following error randomly:

[ERR_BUFFER_OUT_OF_BOUNDS]: Attempt to access memory outside buffer bounds

This was caused by the prime number generation from the diffie-hellman library. We were expecting a 16-bit prime number but sometimes the generated number could fit in 8 bits so this was causing the readUInt16BE() to crash.

Solution: 

A new function was added to check if the generated prime number  is 16-bit, otherwise zeros will be added to get the 16-bit 